### PR TITLE
xsd renderer - use content type application/xml instead of text/xml

### DIFF
--- a/papyrus/renderers.py
+++ b/papyrus/renderers.py
@@ -127,6 +127,6 @@ class XSD(object):
             request = system.get('request')
             if request is not None:
                 response = request.response
-                response.content_type = 'text/xml'
+                response.content_type = 'application/xml'
                 return get_table_xsd(StringIO(), value).getvalue()
         return _render

--- a/papyrus/tests/test_renderers.py
+++ b/papyrus/tests/test_renderers.py
@@ -159,6 +159,7 @@ class Test_XSD(unittest.TestCase):
         t = Table('table', MetaData(), column)
         request = testing.DummyRequest()
         result = renderer(t, {'request': request})
+        self.assertEqual(request.response.content_type, 'application/xml')
         from xml.etree.ElementTree import XML
         xml = XML(result)
         self.assertEquals(xml.tag, '{http://www.w3.org/2001/XMLSchema}schema')


### PR DESCRIPTION
[RFC3023](http://tools.ietf.org/html/rfc3023) states:

> If an XML document -- that is, the unprocessed, source XML document -- is readable by casual users, text/xml is preferable to application/xml.  MIME user agents (and web user agents) that do not have explicit support for text/xml will treat it as text/plain, for example, by displaying the XML MIME entity as plain text. Application/xml is preferable when the XML MIME entity is unreadable by casual users.

XSD is definitely not for human consumption, so `application/xml` is a more appropriate content type than `text/xml`.
