### PR TITLE
xsd renderer - skip primary keys by default

### DIFF
--- a/papyrus/renderers.py
+++ b/papyrus/renderers.py
@@ -109,6 +109,16 @@ class XSD(object):
 
         config.add_renderer('xsd', XSD())
 
+    By default, the XSD renderer will skip columns which are primary keys.  If
+    you wish to include primary keys then pass ``include_primary_keys=True``
+    when creating the XSD object, for example:
+
+    .. code-block:: python
+
+        from papyrus.renderers import XSD
+
+        config.add_renderer('xsd', XSD(include_primary_keys=True))
+
     Once this renderer has been registered as above , you can use
     ``xsd`` as the ``renderer`` parameter to ``@view_config``
     or to the ``add_view`` method on the Configurator object:
@@ -122,11 +132,16 @@ class XSD(object):
             return Spot.__table__
     """
 
+    def __init__(self, include_primary_keys=False):
+        self.include_primary_keys = include_primary_keys
+
     def __call__(self, table):
         def _render(value, system):
             request = system.get('request')
             if request is not None:
                 response = request.response
                 response.content_type = 'application/xml'
-                return get_table_xsd(StringIO(), value).getvalue()
+                io = get_table_xsd(StringIO(), value,
+                        include_primary_keys=self.include_primary_keys)
+                return io.getvalue()
         return _render

--- a/papyrus/tests/test_renderers.py
+++ b/papyrus/tests/test_renderers.py
@@ -145,16 +145,16 @@ class Test_GeoJSON(unittest.TestCase):
 
 class Test_XSD(unittest.TestCase):
 
-    def _callFUT(self):
+    def _callFUT(self, **kwargs):
         from papyrus.renderers import XSD
         fake_info = {}
-        return XSD()(fake_info)
+        return XSD(**kwargs)(fake_info)
 
     def _make_xpath(self, components):
         return '/{http://www.w3.org/2001/XMLSchema}'.join(components.split())
 
-    def _get_elements(self, column):
-        renderer = self._callFUT()
+    def _get_elements(self, column, **kwargs):
+        renderer = self._callFUT(**kwargs)
         from sqlalchemy import MetaData, Table
         t = Table('table', MetaData(), column)
         request = testing.DummyRequest()
@@ -195,6 +195,21 @@ class Test_XSD(unittest.TestCase):
             'name': 'column',
             'nillable': 'true',
             'type': 'other'})
+
+    def test_primary_keys(self):
+        from sqlalchemy import Column, types
+        column = Column('column', types.Integer, primary_key=True)
+        elements = self._get_elements(column)
+        self.assertEqual(len(elements), 0)
+
+    def test_include_primary_keys(self):
+        from sqlalchemy import Column, types
+        column = Column('column', types.Integer, primary_key=True)
+        elements = self._get_elements(column, include_primary_keys=True)
+        self.assertEqual(len(elements), 1)
+        self.assertEqual(elements[0].attrib, {
+            'name': 'column',
+            'type': 'xsd:integer'})
 
     def test_integer(self):
         from sqlalchemy import Column, types

--- a/papyrus/xsd.py
+++ b/papyrus/xsd.py
@@ -113,7 +113,7 @@ def add_column_xsd(tb, column):
     raise UnsupportedColumnTypeError(column.type)
 
 
-def get_columns_xsd(io, name, columns):
+def get_columns_xsd(io, name, columns, include_primary_keys=False):
     """ Returns the XSD for a named collection of columns """
     attrs = {}
     attrs['xmlns:gml'] = 'http://www.opengis.net/gml'
@@ -126,12 +126,14 @@ def get_columns_xsd(io, name, columns):
                          {'base': 'gml:AbstractFeatureType'}) as tb:
                     with tag(tb, 'xsd:sequence') as tb:
                         for column in columns:
+                            if column.primary_key and not include_primary_keys:
+                                continue
                             add_column_xsd(tb, column)
-                        pass
     ElementTree(tb.close()).write(io, encoding='utf-8')
     return io
 
 
-def get_table_xsd(io, table):
+def get_table_xsd(io, table, include_primary_keys=False):
     """ Returns the XSD for a table """
-    return get_columns_xsd(io, table.name, table.columns)
+    return get_columns_xsd(io, table.name, table.columns,
+            include_primary_keys=include_primary_keys)


### PR DESCRIPTION
This pull request causes the XSD renderer to skip primary keys by default. The original behavior can be re-enabled by passing `include_primary_keys=True` as a keyword argument when creating the renderer.
