### PR TITLE
Ignore foreign keys by default, and add callbacks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -207,11 +207,16 @@ Notes:
 * The XSD renderer ignores `relationship properties
   <http://docs.sqlalchemy.org/en/latest/orm/relationships.html#sqlalchemy.orm.relationship>`_.
   A ``relationship_property_callback`` can be registered to handle relationship
-  properties at the application level.
+  properties at the application level. The callback receives three arguments:
+  an ``xml.etree.ElementTree.TreeBuilder``, the mapped class being
+  serialized, and the relationship property key.
 
 * Likewise an ``association_proxy_callback`` can be registered to handle
   `association proxies
   <http://docs.sqlalchemy.org/en/latest/orm/extensions/associationproxy.html>`_.
+  The callback receives three arguments: an
+  ``xml.etree.ElementTree.TreeBuilder``, the mapped class being serialized, and
+  the name of the association proxy property as defined in the mapped class.
 
 MapFish Web Services
 --------------------

--- a/papyrus/renderers.py
+++ b/papyrus/renderers.py
@@ -157,20 +157,22 @@ class XSD(object):
     * ``tb`` A `TreeBuilder
       <http://docs.python.org/library/xml.etree.elementtree.html#xml.etree.ElementTree.TreeBuilder>`_
       object, which can be used to add elements to the XSD.
-    * ``key`` The name of the class property.
-    * ``property`` The class property.
+    * ``cls`` The class being serialized.
+    * ``key`` The property key.
 
     Callback example:
 
     .. code-block: python
 
+        from sqlalchemy.orm.util import class_mapper
         from papyrus.xsd import tag
 
-        def callback(tb, key, property):
+        def callback(tb, cls, key):
+            _property = class_mapper(cls).get_property(key)
             attrs = {}
             attrs['minOccurs'] = str(0)
             attrs['nillable'] = 'true'
-            attrs['name'] = property.key
+            attrs['name'] = _property.key
             with tag(tb, 'xsd:element', attrs) as tb:
                 with tag(tb, 'xsd:simpleType') as tb:
                     with tag(tb, 'xsd:restriction',

--- a/papyrus/xsd.py
+++ b/papyrus/xsd.py
@@ -153,14 +153,13 @@ class XSDGenerator(object):
             if isinstance(p, ColumnProperty):
                 self.add_column_property_xsd(tb, p)
             elif isinstance(p, RelationshipProperty):
-                if callable(self.relationship_property_callback):
-                    self.relationship_property_callback(tb, k, p)
+                cb = self.relationship_property_callback
+                if callable(cb):
+                    cb(tb, cls, k)
             elif isinstance(p, AssociationProxy):
-                if callable(self.association_proxy_callback):
-                    relationship_property = class_mapper(cls) \
-                                    .get_property(p.target_collection)
-                    target = relationship_property.argument
-                    self.association_proxy_callback(tb, k, p)
+                cb = self.association_proxy_callback
+                if callable(cb):
+                    cb(tb, cls, k)
 
     def get_class_xsd(self, io, cls):
         """ Returns the XSD for a mapped class. """


### PR DESCRIPTION
This pull request suggests:
- ignoring foreign keys by default
- adding callbacks for handling _relationship properties_ and _association proxies_
