### PR TITLE
add __add_properties__ to GeoInterface

### DIFF
--- a/papyrus/geojsonencoder.py
+++ b/papyrus/geojsonencoder.py
@@ -1,0 +1,28 @@
+import datetime
+import functools
+
+from sqlalchemy.ext.associationproxy import _AssociationList
+
+from geojson import dumps as _dumps
+from geojson.codec import PyGFPEncoder
+
+
+class GeoJSONEncoder(PyGFPEncoder):
+    # SQLAlchemy's Reflecting Tables mechanism uses decimal.Decimal
+    # for numeric columns and datetime.date for dates. simplejson
+    # doesn't deal with these types. This class provides a simple
+    # encoder to deal with objects of these types.
+
+    def default(self, obj):
+        if isinstance(obj, (datetime.date, datetime.datetime)):
+            return obj.isoformat()
+        if isinstance(obj, _AssociationList):
+            return list(obj)
+        return PyGFPEncoder.default(self, obj)
+
+
+dumps = functools.partial(_dumps, cls=GeoJSONEncoder, use_decimal=True)
+"""
+A partial function for ``geojson.dumps`` that sets ``cls`` to
+:class:`GeoJSONEncoder` and ``use_decimal`` to ``True``.
+"""

--- a/papyrus/renderers.py
+++ b/papyrus/renderers.py
@@ -1,26 +1,15 @@
-import decimal
-import datetime
 try:
     from cStringIO import StringIO
 except ImportError: # pragma: no cover
     from StringIO import StringIO
 
 import geojson
-from geojson.codec import PyGFPEncoder as GeoJSONEncoder
+
+from papyrus.geojsonencoder import dumps
 
 from xsd import get_class_xsd
 
 
-class Encoder(GeoJSONEncoder):
-    # SQLAlchemy's Reflecting Tables mechanism uses decimal.Decimal
-    # for numeric columns and datetime.date for dates. simplejson
-    # does'nt deal with these types. This class provides a simple
-    # encoder to deal with objects of these types.
-
-    def default(self, obj):
-        if isinstance(obj, (datetime.date, datetime.datetime)):
-            return obj.isoformat()
-        return GeoJSONEncoder.default(self, obj)
 
 class GeoJSON(object):
     """ GeoJSON renderer.
@@ -77,7 +66,7 @@ class GeoJSON(object):
         def _render(value, system):
             if isinstance(value, (list, tuple)):
                 value = self.collection_type(value)
-            ret = geojson.dumps(value, cls=Encoder, use_decimal=True)
+            ret = dumps(value)
             request = system.get('request')
             if request is not None:
                 response = request.response

--- a/papyrus/tests/test_geo_interface.py
+++ b/papyrus/tests/test_geo_interface.py
@@ -6,55 +6,135 @@ class GeoInterfaceTests(unittest.TestCase):
     def _get_mapped_class_declarative(self):
         from sqlalchemy import MetaData, Column, types, orm, schema
         from sqlalchemy.ext.declarative import declarative_base
+        from sqlalchemy.ext.associationproxy import association_proxy
         from geoalchemy import GeometryColumn, Geometry
         from papyrus.geo_interface import GeoInterface
         Base = declarative_base(metadata=MetaData())
-        class Child(Base):
-            __tablename__ = 'child'
+
+        class Child1(Base):
+            __tablename__ = 'child1'
             id = Column(types.Integer, primary_key=True)
+            name = Column(types.Unicode)
             parent_id = Column(types.Integer, schema.ForeignKey('parent.id'))
+
+            def __init__(self, name):
+                self.name = name
+
+        class Child2(Base):
+            __tablename__ = 'child2'
+            id = Column(types.Integer, primary_key=True)
+            name = Column(types.Unicode)
+
+            def __init__(self, name):
+                self.name = name
+
         class Parent(GeoInterface, Base):
             __tablename__ = 'parent'
             id = Column(types.Integer, primary_key=True)
             text = Column(types.Unicode)
             geom = GeometryColumn(Geometry(dimension=2, srid=3000))
-            children = orm.relationship(Child, backref="parent")
+            children_ = orm.relationship(Child1, backref="parent")
+            child_id = Column(types.Integer, schema.ForeignKey('child2.id'))
+            child_ = orm.relationship(Child2)
+
+            children = association_proxy('children_', 'name')
+            child = association_proxy('child_', 'name')
+            __add_properties__ = ('child', 'children')
+
         return Parent
 
     def _get_mapped_class_declarative_as_base(self):
         from sqlalchemy import MetaData, Column, types, orm, schema
         from sqlalchemy.ext.declarative import declarative_base
+        from sqlalchemy.ext.associationproxy import association_proxy
         from geoalchemy import GeometryColumn, Geometry
         from papyrus.geo_interface import GeoInterface
         Base = declarative_base(metadata=MetaData(), cls=GeoInterface,
                                 constructor=None)
-        class Child(Base):
-            __tablename__ = 'child'
+
+        class Child1(Base):
+            __tablename__ = 'child1'
             id = Column(types.Integer, primary_key=True)
+            name = Column(types.Unicode)
             parent_id = Column(types.Integer, schema.ForeignKey('parent.id'))
+
+            def __init__(self, name):
+                self.name = name
+
+        class Child2(Base):
+            __tablename__ = 'child2'
+            id = Column(types.Integer, primary_key=True)
+            name = Column(types.Unicode)
+
+            def __init__(self, name):
+                self.name = name
+
         class Parent(Base):
             __tablename__ = 'parent'
             id = Column(types.Integer, primary_key=True)
             text = Column(types.Unicode)
             geom = GeometryColumn(Geometry(dimension=2, srid=3000))
-            children = orm.relationship(Child, backref="parent")
+            children_ = orm.relationship(Child1, backref="parent")
+            child_id = Column(types.Integer, schema.ForeignKey('child2.id'))
+            child_ = orm.relationship(Child2)
+
+            children = association_proxy('children_', 'name')
+            child = association_proxy('child_', 'name')
+            __add_properties__ = ('child', 'children')
+
         return Parent
 
     def _get_mapped_class_non_declarative(self):
-        from sqlalchemy import Table, MetaData, Column, types, orm
+        from sqlalchemy import Table, MetaData, Column, types, orm, schema
+        from sqlalchemy.ext.associationproxy import association_proxy
         from papyrus.geo_interface import GeoInterface
-        from geoalchemy import GeometryExtensionColumn, GeometryColumn, Geometry
+        from geoalchemy import (GeometryExtensionColumn, GeometryColumn,
+                                Geometry)
         from geoalchemy.postgis import PGComparator
-        parent_table = Table('parent', MetaData(),
+
+        md = MetaData()
+
+        child1_table = Table('child1', md,
+            Column('id', types.Integer, primary_key=True),
+            Column('name', types.Unicode),
+            Column('parent_id', types.Integer, schema.ForeignKey('parent.id'))
+            )
+
+        child2_table = Table('child2', md,
+            Column('id', types.Integer, primary_key=True),
+            Column('name', types.Unicode)
+            )
+
+        parent_table = Table('parent', md,
             Column('id', types.Integer, primary_key=True),
             Column('text', types.Unicode),
-            GeometryExtensionColumn('geom', Geometry(dimension=2, srid=3000))
+            GeometryExtensionColumn('geom', Geometry(dimension=2, srid=3000)),
+            Column('child_id', types.Integer, schema.ForeignKey('child2.id'))
             )
+
+        class Child1(object):
+            def __init__(self, name):
+                self.name = name
+
+        orm.mapper(Child1, child1_table)
+
+        class Child2(object):
+            def __init__(self, name):
+                self.name = name
+
+        orm.mapper(Child2, child2_table)
+
         class Parent(GeoInterface):
-            pass
+            children = association_proxy('children_', 'name')
+            child = association_proxy('child_', 'name')
+            __add_properties__ = ('child', 'children')
+
         orm.mapper(Parent, parent_table,
                    properties={'geom': GeometryColumn(parent_table.c.geom,
-                                                      comparator=PGComparator)}
+                                                      comparator=PGComparator),
+                               'children_': orm.relationship(Child1),
+                               'child_': orm.relationship(Child2)
+                              }
                    )
         return Parent
 
@@ -74,14 +154,18 @@ class GeoInterfaceTests(unittest.TestCase):
         from geojson import Feature, Point
         from geoalchemy import WKBSpatialElement
         from shapely import wkb
-        feature = Feature(id=1, properties={'text': 'foo'},
+        feature = Feature(id=1, properties={'text': 'foo', 'child': 'foo',
+                                            'children': ['foo', 'foo']},
                           geometry=Point(coordinates=[53, -4]))
         obj = mapped_class(feature)
-        feature = Feature(id=2, properties={'text': 'bar'},
+        feature = Feature(id=2, properties={'text': 'bar', 'child': 'bar',
+                                            'children': ['bar', 'bar']},
                           geometry=Point(coordinates=[55, -5]))
         obj.__update__(feature)
         self.assertEqual(obj.id, 1)
         self.assertEqual(obj.text, 'bar')
+        self.assertEqual(obj.child, 'bar')
+        self.assertEqual(obj.children, ['bar', 'bar'])
         self.assertTrue(isinstance(obj.geom, WKBSpatialElement))
         point = wkb.loads(str(obj.geom.desc))
         self.assertEqual(point.x, 55)
@@ -104,11 +188,14 @@ class GeoInterfaceTests(unittest.TestCase):
         from geojson import Feature, Point
         from geoalchemy import WKBSpatialElement
         from shapely import wkb
-        feature = Feature(id=1, properties={'text': 'foo'},
+        feature = Feature(id=1, properties={'text': 'foo', 'child': 'foo',
+                                            'children': ['foo', 'foo']},
                           geometry=Point(coordinates=[53, -4]))
         obj = mapped_class(feature)
         self.assertEqual(obj.id, 1)
         self.assertEqual(obj.text, 'foo')
+        self.assertEqual(obj.child, 'foo')
+        self.assertEqual(obj.children, ['foo', 'foo'])
         self.assertTrue(isinstance(obj.geom, WKBSpatialElement))
         point = wkb.loads(str(obj.geom.desc))
         self.assertEqual(point.x, 53)
@@ -128,12 +215,15 @@ class GeoInterfaceTests(unittest.TestCase):
         self._test_geo_interface(mapped_class)
 
     def _test_geo_interface(self, mapped_class):
-        from geojson import Feature, Point, dumps
-        feature = Feature(id=1, properties={'text': 'foo'},
+        from geojson import Feature, Point
+        from papyrus.geojsonencoder import dumps
+        mapped_class = self._get_mapped_class_declarative()
+        feature = Feature(id=1, properties={'text': 'foo', 'child': 'bar',
+                                            'children': ['foo', 'bar']},
                           geometry=Point(coordinates=[53, -4]))
         obj = mapped_class(feature)
         json = dumps(obj)
-        self.assertEqual(json, '{"geometry": {"type": "Point", "coordinates": [53.0, -4.0]}, "type": "Feature", "properties": {"text": "foo"}, "id": 1}')
+        self.assertEqual(json, '{"geometry": {"type": "Point", "coordinates": [53.0, -4.0]}, "type": "Feature", "properties": {"text": "foo", "children": ["foo", "bar"], "child": "bar"}, "id": 1}')  # NOQA
 
     def test_geo_interface_declarative_no_feature(self):
         mapped_class = self._get_mapped_class_declarative()
@@ -157,8 +247,11 @@ class GeoInterfaceTests(unittest.TestCase):
         self._test_geo_interface_declarative_shape_unset(mapped_class)
 
     def _test_geo_interface_declarative_shape_unset(self, mapped_class):
-        from geojson import Feature, Point, dumps
-        feature = Feature(id=1, properties={'text': 'foo'},
+        from geojson import Feature, Point
+        from papyrus.geojsonencoder import dumps
+        mapped_class = self._get_mapped_class_declarative()
+        feature = Feature(id=1, properties={'text': 'foo', 'child': 'foo',
+                                            'children': ['foo', 'foo']},
                           geometry=Point(coordinates=[53, -4]))
         obj = mapped_class(feature)
         # we want to simulate the case where the geometry is read from
@@ -166,4 +259,4 @@ class GeoInterfaceTests(unittest.TestCase):
         del(obj._shape)
         obj.geom.geom_wkb = obj.geom.desc
         json = dumps(obj)
-        self.assertEqual(json, '{"geometry": {"type": "Point", "coordinates": [53.0, -4.0]}, "type": "Feature", "properties": {"text": "foo"}, "id": 1}')
+        self.assertEqual(json, '{"geometry": {"type": "Point", "coordinates": [53.0, -4.0]}, "type": "Feature", "properties": {"text": "foo", "children": ["foo", "foo"], "child": "foo"}, "id": 1}')  # NOQA


### PR DESCRIPTION
This pull request suggests adding an `__add_properties__` property to the `GeoInterface` class. With this user-defined classes can define additional properties (e.g. association proxy properties) that should be considerer by `__read__` and `__update__`.
