### PR TITLE
create_filter returns True instead of None

### DIFF
--- a/papyrus/protocol.py
+++ b/papyrus/protocol.py
@@ -264,7 +264,7 @@ class Protocol(object):
         if filter is None:
             filter = create_filter(request, self.mapped_class, self.geom_attr)
             if filter is not None:
-                query.filter(filter)
+                query = query.filter(filter)
         order_by = self._get_order_by(request)
         if order_by is not None:
             query = query.order_by(order_by)
@@ -277,7 +277,7 @@ class Protocol(object):
         if filter is None:
             filter = create_filter(request, self.mapped_class, self.geom_attr)
         if filter is not None:
-            query.filter(filter)
+            query = query.filter(filter)
         return query.count()
 
     def read(self, request, filter=None, id=None):


### PR DESCRIPTION
Method create_filter should return _True_ instead of _None_ if no geometry nor attribute filter is set.

Compare the generated SQL requests:

> SELECT ... FROM ...
> WHERE NULL

-> No feature is returned

vs.

> SELECT ... FROM ...
> WHERE true

-> All features are returned, if not limited by _limit_ parameter, which is correct according to the MapFish protocol.
