### PR TITLE
Install test packages with pip

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -6,9 +6,9 @@ This file provides the steps for releasing a new version of Papyrus.
 Verify that the version number is correct in ``setup.py`` and ``docs/conf.py``.
 If not then change it, then commit and push.
 
-Verify that the tests pass, with 100% coverage::
+Verify that the tests pass, with 100% (or close) coverage::
 
-    $ python setup.py nosetests
+    $ nosetests
     ......................................................
     Name                               Stmts   Miss  Cover   Missing
     ----------------------------------------------------------------

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,0 +1,7 @@
+nose
+coverage
+WebTest
+psycopg2
+pyramid_handlers
+mock
+simplejson

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,18 +61,20 @@ Papyrus includes unit tests. Most of the time patches should include new tests.
 
 To run the Papyrus tests, in addition to Papyrus and its dependencies the
 following packages need to be installed: ``nose``, ``mock``, ``psycopg2``,
-``simplejson``, ``pyramid_handlers``, and ``coverage``.  There's no need to
-manually install these packages, as they will be installed when the ``setup.py
-nosetests`` command is run.  However, for these packages to install correctly,
-you have to have header files for ``PostgreSQL``, ``Python``, and ``GEOS``. On
-Debian-based systems install the following system packages: ``libpq-dev``,
-``python-dev``, ``libgeos-c1``.
+``simplejson``, ``pyramid_handlers``, ``coverage``, and ``WebTest``.
+
+For these packages to install correctly, you have to have header files for
+``PostgreSQL``, ``Python``, and ``GEOS``. On Debian-based systems install the
+following system packages: ``libpq-dev``, ``python-dev``, ``libgeos-c1``.
+
+Use ``pip`` and the ``dev_requirements.txt`` file to install these packages in
+the virtual environment::
+
+    $ pip install -r dev_requirements.txt
 
 To run the tests::
 
-    $ python setup.py nosetests
-
-100% of the Papyrus code is covered by tests, let's preserve that.
+    $ nosetests
 
 Indices and tables
 ==================

--- a/setup.py
+++ b/setup.py
@@ -15,19 +15,6 @@ install_requires = [
     'GeoAlchemy2>=0.2.4'
     ]
 
-setup_requires = [
-    'nose'
-    ]
-
-tests_require = install_requires + [
-    'coverage',
-    'WebTest',
-    'psycopg2',
-    'simplejson',
-    'pyramid_handlers',
-    'mock'
-    ]
-
 setup(name='papyrus',
       version=version,
       description="Geospatial Extensions for Pyramid",
@@ -47,9 +34,6 @@ setup(name='papyrus',
       include_package_data=True,
       zip_safe=False,
       install_requires=install_requires,
-      setup_requires=setup_requires,
-      tests_require=tests_require,
-      test_suite="papyrus.tests",
       entry_points="""
       # -*- Entry points: -*-
       """,


### PR DESCRIPTION
This is to avoid using the fragile `tests_require` setup option, which does not work correctly when behind a proxy.
